### PR TITLE
Fix GitHub Actions: Update Ruby version to 3.3

### DIFF
--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7
+          ruby-version: '3.3'
           bundler-cache: true
 
       - name: Deploy


### PR DESCRIPTION
## Problem
The GitHub Actions workflow was failing because it was using Ruby 2.7, which is incompatible with the upgraded Jekyll 4.4.1 and Chirpy theme 7.3.1 from PR #5.

## Error Details
From the failed workflow run: https://github.com/shairyar/shairyar.github.io/actions/runs/18588459828/job/52997721964

```
The process '/opt/hostedtoolcache/Ruby/2.7.8/x64/bin/bundle' failed with exit code 7
Your bundle is locked to ffi (1.17.2-x86_64-linux) from rubygems repository
```

## Solution
- Updated the GitHub Actions workflow to use Ruby 3.3 instead of Ruby 2.7
- This matches the local development environment and is compatible with all upgraded dependencies

## Testing
- ✅ Workflow should now successfully install dependencies
- ✅ Compatible with Jekyll 4.4.1 and Chirpy 7.3.1
- ✅ Matches the Ruby version used locally (Ruby 3.3.5)